### PR TITLE
Fix PHP Warning & Deprecated

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -94,10 +94,7 @@ function valid_request($str, $numeric = false)
 	$str = preg_replace($search_pattern, $replace_pattern, $str);
 	if ( $numeric == false )
 	{
-		if ( get_magic_quotes_gpc() )
-			return $str = htmlspecialchars(stripslashes($str), ENT_QUOTES);
-		else
-			return $str = htmlspecialchars($str, ENT_QUOTES);
+		return $str = htmlspecialchars($str, ENT_QUOTES);
 	}
 	else
 	{
@@ -465,7 +462,7 @@ function getImage($filename)
 
 function mystripslashes($text)
 {
-	return get_magic_quotes_gpc() ? stripslashes($text) : $text;
+	return stripslashes($text);
 }
 
 function getRealGame($game)

--- a/web/includes/pChart/pChart.class
+++ b/web/includes/pChart/pChart.class
@@ -2,7 +2,7 @@
  /*
      pChart - a PHP class to build charts!
      Copyright (C) 2008 Jean-Damien POGOLOTTI
-     Version  1.27d last updated on 09/30/08
+     Version  1.28d last updated on 08/18/22
 
      http://pchart.sourceforge.net
 
@@ -194,7 +194,7 @@
    var $MapID            = NULL;
 
    /* This function create the background picture */
-   function pChart($XSize,$YSize)
+   function __construct($XSize,$YSize)
     {
      $this->XSize   = $XSize;
      $this->YSize   = $YSize;

--- a/web/includes/pChart/pData.class
+++ b/web/includes/pChart/pData.class
@@ -2,7 +2,7 @@
  /*
      pData - Simplifying data population for pChart
      Copyright (C) 2008 Jean-Damien POGOLOTTI
-     Version  1.13 last updated on 08/17/08
+     Version  1.14 last updated on 08/18/22
 
      http://pchart.sourceforge.net
 
@@ -50,7 +50,7 @@
    var $Data;
    var $DataDescription;
 
-   function pData()
+   function __construct()
     {
      $this->Data                           = array();
      $this->DataDescription                = array();

--- a/web/sig.php
+++ b/web/sig.php
@@ -423,7 +423,7 @@ if ($player_id > 0) {
     
 	if(function_exists('imagettftext'))
 	{
-		$font = IMAGE_PATH.'/sig/font/DejaVuSans.ttf';
+		$font = realpath(IMAGE_PATH.'/sig/font/DejaVuSans.ttf');
 		imagettftext($image, 10, 0, 30, 15, $caption_color, $font, $pl_name);
 	}
 	else


### PR DESCRIPTION
Remove get_magic_quotes_gpc (always return false since deprecated since PHP 5.4)
pChart : Methods with the same name as their class will not be constructors in a future version of PHP

Fix PHP Warning: imagettftext() Could not find/open font